### PR TITLE
add_membership_groups_to_weekly_adverts

### DIFF
--- a/configurations/s02_pipeline_configuration.py
+++ b/configurations/s02_pipeline_configuration.py
@@ -107,9 +107,10 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
             drive_dir="leap_s02_analysis_outputs"
         ),
         membership_group_configuration=MembershipGroupConfiguration(
-            membership_group_csv_urls={"listening_group": [
-                "gs://avf-project-datasets/2021/WUSC-LEAP/leap_s02_listening_group.csv"
-            ]
+            membership_group_csv_urls={
+                "listening_group": [
+                    "gs://avf-project-datasets/2021/WUSC-LEAP/leap_s02_listening_group.csv"
+                ]
             },
         ),
         dataset_configurations=[

--- a/configurations/s02_pipeline_configuration.py
+++ b/configurations/s02_pipeline_configuration.py
@@ -106,6 +106,12 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
             credentials_file_url="gs://avf-credentials/pipeline-runner-service-acct-avf-data-core-64cc71459fe7.json",
             drive_dir="leap_s02_analysis_outputs"
         ),
+        membership_group_configuration=MembershipGroupConfiguration(
+            membership_group_csv_urls={"listening_group": [
+                "gs://avf-project-datasets/2021/WUSC-LEAP/leap_s02_listening_group.csv"
+            ]
+            },
+        ),
         dataset_configurations=[
             AnalysisDatasetConfiguration(
                 engagement_db_datasets=["leap_s02e01"],

--- a/export_weekly_ad_contacts.py
+++ b/export_weekly_ad_contacts.py
@@ -58,6 +58,7 @@ if __name__ == "__main__":
 
     #If available, add consented membership group uids to advert uuids
     if pipeline_config.analysis.membership_group_configuration is not None:
+        log.info(f"Adding consented membership group uids to advert uuids ")
         membership_group_csv_urls = \
             pipeline_config.analysis.membership_group_configuration.membership_group_csv_urls.items()
 
@@ -66,26 +67,27 @@ if __name__ == "__main__":
 
         consented_membership_groups_uuids = 0
         opt_out_membership_groups_uuids = 0
-        for uuid in membership_groups_data.values():
-            if uuid in opt_out_uuids:
-                opt_out_membership_groups_uuids += 1
-                continue
+        for membership_group in membership_groups_data.values():
+            for uuid in membership_group:
+                if uuid in opt_out_uuids:
+                    opt_out_membership_groups_uuids += 1
+                    continue
 
-            uuids.add(uuid)
-            consented_membership_groups_uuids +=1
+                consented_membership_groups_uuids += 1
+                uuids.add(uuid)
 
         log.info(f"Found {opt_out_membership_groups_uuids} membership_groups_uuids who have opted out")
         log.info(f"Added {consented_membership_groups_uuids} membership_groups_uuids to advert uuids")
 
 
-    log.info(f"Loaded {len(uuids)} uuids from TracedData (of which {len(opt_out_uuids)} uuids withdrew consent)")
+    log.info(f"Loaded {len(uuids)} uuids  (of which {len(opt_out_uuids)} uuids withdrew consent)")
     advert_uuids = uuids - opt_out_uuids
-    log.info(f"Proceeding with {len(uuids)} opt-in uuids")
+    log.info(f"Proceeding with {len(advert_uuids)} opt-in uuids")
 
-    log.info(f"Converting {len(uuids)} uuids to urns...")
+    log.info(f"Converting {len(advert_uuids)} uuids to urns...")
     urn_lut = uuid_table.uuid_to_data_batch(advert_uuids)
     urns = {urn_lut[uuid] for uuid in advert_uuids}
-    log.info(f"Converted {len(advert_uuids)} to {len(urns)}")
+    log.info(f"Converted {len(advert_uuids)} uuids to {len(urns)} urns")
 
     # Export contacts CSV
     log.warning(f"Exporting {len(urns)} urns to {csv_output_file_path}...")

--- a/export_weekly_ad_contacts.py
+++ b/export_weekly_ad_contacts.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
             uuids.add(td["participant_uuid"])
 
-    #If available, add consented membership group uids to advert uuids
+    # If available, add consented membership group uids to advert uuids
     if pipeline_config.analysis.membership_group_configuration is not None:
         log.info(f"Adding consented membership group uids to advert uuids ")
         membership_group_csv_urls = \

--- a/export_weekly_ad_contacts.py
+++ b/export_weekly_ad_contacts.py
@@ -79,7 +79,6 @@ if __name__ == "__main__":
         log.info(f"Found {opt_out_membership_groups_uuids} membership_groups_uuids who have opted out")
         log.info(f"Added {consented_membership_groups_uuids} membership_groups_uuids to advert uuids")
 
-
     log.info(f"Loaded {len(uuids)} uuids  (of which {len(opt_out_uuids)} uuids withdrew consent)")
     advert_uuids = uuids - opt_out_uuids
     log.info(f"Proceeding with {len(advert_uuids)} opt-in uuids")

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -12,8 +12,7 @@ from src.engagement_db_to_analysis.code_imputation_functions import (impute_code
 from src.engagement_db_to_analysis.column_view_conversion import (convert_to_messages_column_format,
                                                                   convert_to_participants_column_format)
 from src.engagement_db_to_analysis.traced_data_filters import filter_messages
-from src.engagement_db_to_analysis.membership_group import (get_membership_groups_csvs,
-                                                            tag_membership_groups_participants)
+from src.engagement_db_to_analysis.membership_group import (tag_membership_groups_participants)
 
 log = Logger(__name__)
 
@@ -196,14 +195,13 @@ def generate_analysis_files(user, google_cloud_credentials_file_path, pipeline_c
 
         membership_group_csv_urls = pipeline_config.analysis.membership_group_configuration.membership_group_csv_urls.items()
 
-        log.info("Downloading membership groups CSVs from g-cloud...")
-        get_membership_groups_csvs(google_cloud_credentials_file_path, membership_group_csv_urls, membership_group_dir_path)
-
         log.info("Tagging membership group participants to messages_by_column traced data...")
-        tag_membership_groups_participants(user, messages_by_column, membership_group_csv_urls, membership_group_dir_path)
+        tag_membership_groups_participants(user, google_cloud_credentials_file_path, messages_by_column,
+                                           membership_group_csv_urls, membership_group_dir_path)
 
         log.info("Tagging membership group participants to participants_by_column traced data...")
-        tag_membership_groups_participants(user, participants_by_column, membership_group_csv_urls, membership_group_dir_path)
+        tag_membership_groups_participants(user, participants_by_column,
+                                           membership_group_csv_urls, membership_group_dir_path)
 
     export_analysis_file(messages_by_column, pipeline_config, f"{output_dir}/messages.csv", export_timestamps=True)
     export_analysis_file(participants_by_column, pipeline_config, f"{output_dir}/participants.csv")

--- a/src/engagement_db_to_analysis/membership_group.py
+++ b/src/engagement_db_to_analysis/membership_group.py
@@ -11,9 +11,9 @@ from core_data_modules.traced_data import Metadata
 log = Logger(__name__)
 
 
-def get_membership_groups_csvs(google_cloud_credentials_file_path, membership_group_csv_urls, membership_group_dir_path):
+def get_membership_groups_data(google_cloud_credentials_file_path, membership_group_csv_urls, membership_group_dir_path):
     """
-    Downloads de-identified membership groups CSVs from g-cloud.
+    Downloads de-identified membership groups CSVs from g-cloud and groups them by their group identity.
     :param google_cloud_credentials_file_path: Path to the Google Cloud service account credentials file to use to
                                                access the credentials bucket.
     :type google_cloud_credentials_file_path: str
@@ -43,24 +43,8 @@ def get_membership_groups_csvs(google_cloud_credentials_file_path, membership_gr
             except NotFound:
                 log.warning(f"{membership_group_csv}' not found in google cloud, skipping download")
 
-
-def tag_membership_groups_participants(user, column_view_traced_data, membership_group_csv_urls, membership_group_dir_path):
-    """
-    This tags uids who participated in projects membership groups.
-    :param user: Identifier of the user running this program, for TracedData Metadata.
-    :type user: str
-    :param column_view_traced_data: Messages/Participants TracedData organised into column-view format.
-    :type: list of core_data_modules.traced_data.TracedData
-    :param membership_group_dir_path: Path to directory containing de-identified membership groups CSVs containing membership groups data
-                        stored as `avf-phone-uuid` and `Name` columns.
-    :type membership_group_dir_path: str
-    :param membership_group_csv_urls: Dict of membership group name to group g-cloud csv url(s).
-    :type membership_group_csv_urls: Dict
-    """
-
-    membership_group_participants = dict() # of group name to group avf-participant-uuid(s)
-
     # Read listening group participants CSVs and add their uids to the respective group
+    membership_group_participants = dict()  # of group name to group avf-participant-uuid(s)
     for membership_group, csv_urls in membership_group_csv_urls:
         membership_group_participants[membership_group] = set()
         for i, csv_url in enumerate(csv_urls):
@@ -76,9 +60,26 @@ def tag_membership_groups_participants(user, column_view_traced_data, membership
             else:
                 log.warning(f"{membership_group_csv} does not exist in {membership_group_dir_path} skipping!")
 
-        log.info(f'Loaded {len(membership_group_participants[membership_group])} {membership_group} uids')
+        log.info(f'Loaded {len(membership_group_participants[membership_group])} {membership_group} participant uids')
+
+    return membership_group_participants
+
+
+def tag_membership_groups_participants(user, column_view_traced_data, google_cloud_credentials_file_path,
+                                                               membership_group_csv_urls, membership_group_dir_path):
+    """
+    This tags uids who participated in projects membership groups.
+    :param user: Identifier of the user running this program, for TracedData Metadata.
+    :type user: str
+    :param column_view_traced_data: Messages/Participants TracedData organised into column-view format.
+    :type: list of core_data_modules.traced_data.TracedData
+    """
 
     # Tag a participant based on the membership group type they belong to
+
+    membership_group_participants = get_membership_groups_data(google_cloud_credentials_file_path,
+                                                               membership_group_csv_urls, membership_group_dir_path)
+
     for td in column_view_traced_data:
         membership_group_participation_data = dict()
 

--- a/src/engagement_db_to_analysis/membership_group.py
+++ b/src/engagement_db_to_analysis/membership_group.py
@@ -27,10 +27,11 @@ def get_membership_groups_data(google_cloud_credentials_file_path, membership_gr
         for i, membership_group_csv_url in enumerate(membership_group_csv_url):
             membership_group_csv = membership_group_csv_url.split("/")[-1]
 
+            log.info(f"Downloading {membership_group_csv} from g-cloud...")
             export_file_path = f'{membership_group_dir_path}/{membership_group_csv}'
 
             if os.path.exists(export_file_path):
-                log.info(f"File '{membership_group_csv}' already exists, skipping download")
+                log.info(f"File '{membership_group_csv}' already exists, skipping download..")
                 continue
 
             try:


### PR DESCRIPTION
This adds support for adding  membership_groups_to_weekly_adverts through the following changes
- Modifies the membership_group module so we can reuse the function get_membership_groups_data() in export_weekly_ad_contacts script
- Adds the necessary logic to add membership_groups_uuids to advert contacts. 