### PR TITLE
update advert contact fields instead of adding to groups

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "master",extras=["mapping"]}
-RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "add_get_groups"}
+RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "retry_on_TembaHttpError_500"}
 CodaV2PythonClient = {editable = true,git = "https://www.github.com/AfricasVoices/CodaV2PythonClient",ref = "resolve-type-error"}
 PipelineInfrastructure = {editable = true,git = "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",ref = "v0.1.2"}
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a6f6eee848eec5886832e1c062c82ea16e37277004ca98b67e86e1156981e85e"
+            "sha256": "6629cfad9a21a55a279de3a790b5a339a1dc7ecdbc8f7d9148c82b1dd0ce9da6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,11 +34,11 @@
         },
         "cachetools": {
             "hashes": [
-                "sha256:89ea6f1b638d5a73a4f9226be57ac5e4f399d22770b92355f92dcb0f7f001693",
-                "sha256:92971d3cb7d2a97efff7c7bb1657f21a8f5fb309a37530537c71b1774189f2d1"
+                "sha256:486471dfa8799eb7ec503a8059e263db000cdda20075ce5e48903087f79d5fd6",
+                "sha256:8fecd4203a38af17928be7b90689d8083603073622229ca7077b72d8e5a976e4"
             ],
-            "markers": "python_version ~= '3.5'",
-            "version": "==4.2.4"
+            "markers": "python_version ~= '3.7'",
+            "version": "==5.0.0"
         },
         "certifi": {
             "hashes": [
@@ -49,11 +49,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd",
-                "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.10"
+            "version": "==2.0.12"
         },
         "click": {
             "hashes": [
@@ -75,7 +75,7 @@
                 "sha256:a4bc13d623356b373c2c27c53dbd9c68cae5d526270bfa71f6c6fa69669c6b27",
                 "sha256:c1ca117dbce1fe20a5809dc96f01e1c2840f6dcc939b3ddbb1111bf330ba82df"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
             "version": "==0.7.2"
         },
         "codav2pythonclient": {
@@ -85,11 +85,9 @@
         },
         "coredatamodules": {
             "editable": true,
-            "extras": [
-                "mapping"
-            ],
+            "extras": [],
             "git": "https://github.com/AfricasVoices/CoreDataModules",
-            "ref": "05df823deadbda10d586c4a045949e788083aa82"
+            "ref": "3e61a46b5e8a0f4d32513d2dc934c4a18c5bbf8f"
         },
         "cycler": {
             "hashes": [
@@ -109,17 +107,19 @@
         },
         "fiona": {
             "hashes": [
-                "sha256:02880556540e36ad6aac97687799d9b3093c354787a47bc0e73026c7fc15f1b3",
-                "sha256:03f910380dbe684730b59b817aa030e6e9a3ee79211b66c6db2d1c8fe6ea12de",
-                "sha256:328340a448bed5c43d119f61f760368a04d13a302c59d2fccb051a3ff021f4b8",
-                "sha256:3f668c471fa2f8c9c0a9ca83639cb2c8dcc93edc3d93d43dba2f9e8da38ad53e",
-                "sha256:54f81039e913d0f88728ef23edf5a69038dec94dea54f4c799f972ba8e2a7d40",
-                "sha256:5e1cef608c6de9039eaa65b395024096e3189ab0559a5a328c68c4690c3302ce",
-                "sha256:a70502d2857b82f749c09cb0dea3726787747933a2a1599b5ab787d74e3c143b",
-                "sha256:bef100ebd82afb9a4d67096216e82611b82ca9341330e4805832d7ff8c9bc1f7",
-                "sha256:e72e4a5b84ec410be531d4fe4c1a5c87c6c0e92d01116c145c0f1b33f81c8080"
+                "sha256:085f18d943097ac3396f3f9664ac1ae04ad0ff272f54829f03442187f01b6116",
+                "sha256:11532ccfda1073d3f5f558e4bb78d45b268e8680fd6e14993a394c564ddbd069",
+                "sha256:315e186cb880a8128e110312eb92f5956bbc54d7152af999d3483b463758d6f9",
+                "sha256:3789523c811809a6e2e170cf9c437631f959f4c7a868f024081612d30afab468",
+                "sha256:388acc9fa07ba7858d508dfe826d4b04d813818bced16c4049de19cc7ca322ef",
+                "sha256:39c656421e25b4d0d73d0b6acdcbf9848e71f3d9b74f44c27d2d516d463409ae",
+                "sha256:3a0edca2a7a070db405d71187214a43d2333a57b4097544a3fcc282066a58bfc",
+                "sha256:40b4eaf5b88407421d6c9e707520abd2ff16d7cd43efb59cd398aa41d2de332c",
+                "sha256:43b1d2e45506e56cf3a9f59ba5d6f7981f3f75f4725d1e6cb9a33ba856371ebd",
+                "sha256:9fb2407623c4f44732a33b3f056f8c58c54152b51f0324bf8f10945e711eb549",
+                "sha256:b69054ed810eb7339d7effa88589afca48003206d7627d0b0b149715fc3fde41"
             ],
-            "version": "==1.8.20"
+            "version": "==1.8.21"
         },
         "firebase-admin": {
             "hashes": [
@@ -138,29 +138,31 @@
             "version": "==0.10.2"
         },
         "google-api-core": {
-            "extras": [],
+            "extras": [
+                "grpc"
+            ],
             "hashes": [
-                "sha256:58e2c1171a3d51778bf4e428fbb4bf79cbd05007b4b44deaa80cf73c80eebc0f",
-                "sha256:ba8787b7c61632cd0340f095e1c036bef9426b2594f10afb290ba311ae8cb2cb"
+                "sha256:7d030edbd3a0e994d796e62716022752684e863a6df9864b6ca82a1616c2a5a6",
+                "sha256:f33863a6709651703b8b18b67093514838c79f2b04d02aa501203079f24b8018"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:038b12979ea86ef0e33962bd33f955c337bc28f0471522bd27a801d52bfb4ae2",
-                "sha256:30ccd570ce0018dfc604438cc1e72d215f0d3d5844318729d29a1392ef131056"
+                "sha256:39bb945d00ce5f70207a312b32418c238f3ae16559e30c4ff10dac1e0ed69244",
+                "sha256:8f9176e4f26c11b2561c43458da33d82425673d32298114e26d0e0a83c2011bc"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.35.0"
+            "version": "==2.37.0"
         },
         "google-auth": {
             "hashes": [
-                "sha256:a348a50b027679cb7dae98043ac8dbcc1d7951f06d8387496071a1e05a2465c0",
-                "sha256:d83570a664c10b97a1dc6f8df87e5fdfff012f48f62be131e449c20dfc32630e"
+                "sha256:218ca03d7744ca0c8b6697b6083334be7df49b7bf76a69d555962fd1a7657b5f",
+                "sha256:ad160fc1ea8f19e331a16a14a79f3d643d813a69534ba9611d2c80dc10439dad"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.3.3"
+            "version": "==2.6.0"
         },
         "google-auth-httplib2": {
             "hashes": [
@@ -171,11 +173,11 @@
         },
         "google-cloud-core": {
             "hashes": [
-                "sha256:476d1f71ab78089e0638e0aaf34bfdc99bab4fce8f4170ba6321a5243d13c5c7",
-                "sha256:ab6cee07791afe4e210807ceeab749da6a076ab16d496ac734bf7e6ffea27486"
+                "sha256:7d19bf8868b410d0bdf5a03468a3f3f2db233c0ee86a023f4ecc2b7a4b15f736",
+                "sha256:d9cffaf86df6a876438d4e8471183bbe404c9a15de9afe60433bc7dce8cb4252"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.2.1"
+            "version": "==2.2.2"
         },
         "google-cloud-firestore": {
             "hashes": [
@@ -187,11 +189,11 @@
         },
         "google-cloud-storage": {
             "hashes": [
-                "sha256:a57a15aead0f9dfbd4381f1bfdbe8bf89818a4bd75bab846cafcefb2db846c47",
-                "sha256:ec4be60bb223a3a960f0d01697d849b86d91cad815a84915a32ed3635e93a5e7"
+                "sha256:0a5e7ab1a38d2c24be8e566e50b8b0daa8af8fd49d4ab312b1fda5c147429893",
+                "sha256:53e4f6030d771526e4dbe9c6000cca44eab812f39ae8c7a810be999473e4f02c"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.0"
         },
         "google-crc32c": {
             "hashes": [
@@ -244,11 +246,11 @@
         },
         "google-resumable-media": {
             "hashes": [
-                "sha256:725b989e0dd387ef2703d1cc8e86217474217f4549593c477fd94f4024a0f911",
-                "sha256:cdc75ea0361e39704dc7df7da59fbd419e73c8bc92eac94d8a020d36baa9944b"
+                "sha256:b1edfb98867c9fa25aa7af12d6468665b83c532b7349effab805a027ea8bbee5",
+                "sha256:fd616af31b83d48da040c8c09b6994606e1734efb8af9acc97cf5d6070e9ba72"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.1.0"
+            "version": "==2.2.1"
         },
         "googleapis-common-protos": {
             "hashes": [
@@ -316,11 +318,11 @@
         },
         "httplib2": {
             "hashes": [
-                "sha256:6b937120e7d786482881b44b8eec230c1ee1c5c1d06bce8cc865f25abbbf713b",
-                "sha256:e404681d2fbcec7506bcb52c503f2b021e95bee0ef7d01e5c221468a2406d8dc"
+                "sha256:58a98e45b4b1a48273073f905d2961666ecf0fbac4250ea5b47aef259eb5c585",
+                "sha256:8b6a905cb1c79eefd03f8669fd993c36dc341f7c558f056cb5a33b5c2f458543"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.20.2"
+            "version": "==0.20.4"
         },
         "idna": {
             "hashes": [
@@ -489,31 +491,28 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:0d245a2bf79188d3f361137608c3cd12ed79076badd743dc660750a9f3074f7c",
-                "sha256:26b4018a19d2ad9606ce9089f3d52206a41b23de5dfe8dc947d2ec49ce45d015",
-                "sha256:2db01d9838a497ba2aa9a87515aeaf458f42351d72d4e7f3b8ddbd1eba9479f2",
-                "sha256:3d62d6b0870b53799204515145935608cdeb4cebb95a26800b6750e48884cc5b",
-                "sha256:45a7dfbf9ed8d68fd39763940591db7637cf8817c5bce1a44f7b56c97cbe211e",
-                "sha256:4ac4d7c9f8ea2a79d721ebfcce81705fc3cd61a10b731354f1049eb8c99521e8",
-                "sha256:60f19c61b589d44fbbab8ff126640ae712e163299c2dd422bfe4edc7ec51aa9b",
-                "sha256:632e062569b0fe05654b15ef0e91a53c0a95d08ffe698b66f6ba0f927ad267c2",
-                "sha256:65f5e257987601fdfc63f1d02fca4d1c44a2b85b802f03bd6abc2b0b14648dd2",
-                "sha256:69958735d5e01f7b38226a6c6e7187d72b7e4d42b6b496aca5860b611ca0c193",
-                "sha256:78bfbdf809fc236490e7e65715bbd98377b122f329457fffde206299e163e7f3",
-                "sha256:7e957ca8112c689b728037cea9c9567c27cf912741fabda9efc2c7d33d29dfa1",
-                "sha256:800dfeaffb2219d49377da1371d710d7952c9533b57f3d51b15e61c4269a1b5b",
-                "sha256:831f2df87bd3afdfc77829bc94bd997a7c212663889d56518359c827d7113b1f",
-                "sha256:88d54b7b516f0ca38a69590557814de2dd638d7d4ed04864826acaac5ebb8f01",
-                "sha256:8d1563060e77096367952fb44fca595f2b2f477156de389ce7c0ade3aef29e21",
-                "sha256:b5ec9a5eaf391761c61fd873363ef3560a3614e9b4ead17347e4deda4358bca4",
-                "sha256:bcd19dab43b852b03868796f533b5f5561e6c0e3048415e675bec8d2e9d286c1",
-                "sha256:c51124df17f012c3b757380782ae46eee85213a3215e51477e559739f57d9bf6",
-                "sha256:e348ccf5bc5235fc405ab19d53bec215bb373300e5523c7b476cc0da8a5e9973",
-                "sha256:e60ef82c358ded965fdd3132b5738eade055f48067ac8a5a8ac75acc00cad31f",
-                "sha256:f8ad59e6e341f38266f1549c7c2ec70ea0e3d1effb62a44e5c3dba41c55f0187"
+                "sha256:03ae5850619abb34a879d5f2d4bb4dcd025d6d8fb72f5e461dae84edccfe129f",
+                "sha256:076aee5a3763d41da6bef9565fdf3cb987606f567cd8b104aded2b38b7b47abf",
+                "sha256:0b536b6840e84c1c6a410f3a5aa727821e6108f3454d81a5cd5900999ef04f89",
+                "sha256:15efb7b93806d438e3bc590ca8ef2f953b0ce4f86f337ef4559d31ec6cf9d7dd",
+                "sha256:168259b1b184aa83a514f307352c25c56af111c269ffc109d9704e81f72e764b",
+                "sha256:2638389562bda1635b564490d76713695ff497242a83d9b684d27bb4a6cc9d7a",
+                "sha256:3556c5550de40027d3121ebbb170f61bbe19eb639c7ad0c7b482cd9b560cd23b",
+                "sha256:4a176959b6e7e00b5a0d6f549a479f869829bfd8150282c590deee6d099bbb6e",
+                "sha256:515a8b6edbb904594685da6e176ac9fbea8f73a5ebae947281de6613e27f1956",
+                "sha256:55535c7c2f61e2b2fc817c5cbe1af7cb907c7f011e46ae0a52caa4be1f19afe2",
+                "sha256:59153979d60f5bfe9e4c00e401e24dfe0469ef8da6d68247439d3278f30a180f",
+                "sha256:60cb8e5933193a3cc2912ee29ca331e9c15b2da034f76159b7abc520b3d1233a",
+                "sha256:6767ad399e9327bfdbaa40871be4254d1995f4a3ca3806127f10cec778bd9896",
+                "sha256:76a4f9bce0278becc2da7da3b8ef854bed41a991f4226911a24a9711baad672c",
+                "sha256:8cf33634b60c9cef346663a222d9841d3bbbc0a2f00221d6bcfd0d993d5543f6",
+                "sha256:94dd11d9f13ea1be17bac39c1942f527cbf7065f94953cf62dfe805653da2f8f",
+                "sha256:aafa46b5a39a27aca566198d3312fb3bde95ce9677085efd02c86f7ef6be4ec7",
+                "sha256:badca914580eb46385e7f7e4e426fea6de0a37b9e06bec252e481ae7ec287082",
+                "sha256:d76a26c5118c4d96e264acc9e3242d72e1a2b92e739807b3b69d8d47684b6677"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.22.1"
+            "version": "==1.22.2"
         },
         "oauth2client": {
             "hashes": [
@@ -532,72 +531,71 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1",
-                "sha256:2651d75b9a167cc8cc572cf787ab512d16e316ae00ba81874b560586fa1325e0",
-                "sha256:2c21778a688d3712d35710501f8001cdbf96eb70a7c587a3d5613573299fdca6",
-                "sha256:32e1a26d5ade11b547721a72f9bfc4bd113396947606e00d5b4a5b79b3dcb006",
-                "sha256:3345343206546545bc26a05b4602b6a24385b5ec7c75cb6059599e3d56831da2",
-                "sha256:344295811e67f8200de2390093aeb3c8309f5648951b684d8db7eee7d1c81fb7",
-                "sha256:37f06b59e5bc05711a518aa10beaec10942188dccb48918bb5ae602ccbc9f1a0",
-                "sha256:552020bf83b7f9033b57cbae65589c01e7ef1544416122da0c79140c93288f56",
-                "sha256:5cce0c6bbeb266b0e39e35176ee615ce3585233092f685b6a82362523e59e5b4",
-                "sha256:5f261553a1e9c65b7a310302b9dbac31cf0049a51695c14ebe04e4bfd4a96f02",
-                "sha256:60a8c055d58873ad81cae290d974d13dd479b82cbb975c3e1fa2cf1920715296",
-                "sha256:62d5b5ce965bae78f12c1c0df0d387899dd4211ec0bdc52822373f13a3a022b9",
-                "sha256:7d28a3c65463fd0d0ba8bbb7696b23073efee0510783340a44b08f5e96ffce0c",
-                "sha256:8025750767e138320b15ca16d70d5cdc1886e8f9cc56652d89735c016cd8aea6",
-                "sha256:8b6dbec5f3e6d5dc80dcfee250e0a2a652b3f28663492f7dab9a24416a48ac39",
-                "sha256:a395692046fd8ce1edb4c6295c35184ae0c2bbe787ecbe384251da609e27edcb",
-                "sha256:a62949c626dd0ef7de11de34b44c6475db76995c2064e2d99c6498c3dba7fe58",
-                "sha256:aaf183a615ad790801fa3cf2fa450e5b6d23a54684fe386f7e3208f8b9bfbef6",
-                "sha256:adfeb11be2d54f275142c8ba9bf67acee771b7186a5745249c7d5a06c670136b",
-                "sha256:b6b87b2fb39e6383ca28e2829cddef1d9fc9e27e55ad91ca9c435572cdba51bf",
-                "sha256:bd971a3f08b745a75a86c00b97f3007c2ea175951286cdda6abe543e687e5f2f",
-                "sha256:c69406a2808ba6cf580c2255bcf260b3f214d2664a3a4197d0e640f573b46fd3",
-                "sha256:d3bc49af96cd6285030a64779de5b3688633a07eb75c124b0747134a63f4c05f",
-                "sha256:fd541ab09e1f80a2a1760032d665f6e032d8e44055d602d65eeea6e6e85498cb",
-                "sha256:fe95bae4e2d579812865db2212bb733144e34d0c6785c0685329e5b60fcb85dd"
+                "sha256:0259cd11e7e6125aaea3af823b80444f3adad6149ff4c97fef760093598b3e34",
+                "sha256:04dd15d9db538470900c851498e532ef28d4e56bfe72c9523acb32042de43dfb",
+                "sha256:0b1a13f647e4209ed7dbb5da3497891d0045da9785327530ab696417ef478f84",
+                "sha256:19f7c632436b1b4f84615c3b127bbd7bc603db95e3d4332ed259dc815c9aaa26",
+                "sha256:1b384516dbb4e6aae30e3464c2e77c563da5980440fbdfbd0968e3942f8f9d70",
+                "sha256:1d85d5f6be66dfd6d1d8d13b9535e342a2214260f1852654b19fa4d7b8d1218b",
+                "sha256:2e5a7a1e0ecaac652326af627a3eca84886da9e667d68286866d4e33f6547caf",
+                "sha256:3129a35d9dad1d80c234dd78f8f03141b914395d23f97cf92a366dcd19f8f8bf",
+                "sha256:358b0bc98a5ff067132d23bf7a2242ee95db9ea5b7bbc401cf79205f11502fd3",
+                "sha256:3dfb32ed50122fe8c5e7f2b8d97387edd742cc78f9ec36f007ee126cd3720907",
+                "sha256:4e1176f45981c8ccc8161bc036916c004ca51037a7ed73f2d2a9857e6dbe654f",
+                "sha256:508c99debccd15790d526ce6b1624b97a5e1e4ca5b871319fb0ebfd46b8f4dad",
+                "sha256:6105af6533f8b63a43ea9f08a2ede04e8f43e49daef0209ab0d30352bcf08bee",
+                "sha256:6d6ad1da00c7cc7d8dd1559a6ba59ba3973be6b15722d49738b2be0977eb8a0c",
+                "sha256:7ea47ba1d6f359680130bd29af497333be6110de8f4c35b9211eec5a5a9630fa",
+                "sha256:8db93ec98ac7cb5f8ac1420c10f5e3c43533153f253fe7fb6d891cf5aa2b80d2",
+                "sha256:96e9ece5759f9b47ae43794b6359bbc54805d76e573b161ae770c1ea59393106",
+                "sha256:bbb15ad79050e8b8d39ec40dd96a30cd09b886a2ae8848d0df1abba4d5502a67",
+                "sha256:c614001129b2a5add5e3677c3a213a9e6fd376204cb8d17c04e84ff7dfc02a73",
+                "sha256:e6a7bbbb7950063bfc942f8794bc3e31697c020a14f1cd8905fc1d28ec674a01",
+                "sha256:f02e85e6d832be37d7f16cf6ac8bb26b519ace3e5f3235564a91c7f658ab2a43"
             ],
-            "markers": "python_full_version >= '3.7.1'",
-            "version": "==1.3.5"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.4.1"
         },
         "pillow": {
             "hashes": [
-                "sha256:03b27b197deb4ee400ed57d8d4e572d2d8d80f825b6634daf6e2c18c3c6ccfa6",
-                "sha256:0b281fcadbb688607ea6ece7649c5d59d4bbd574e90db6cd030e9e85bde9fecc",
-                "sha256:0ebd8b9137630a7bbbff8c4b31e774ff05bbb90f7911d93ea2c9371e41039b52",
-                "sha256:113723312215b25c22df1fdf0e2da7a3b9c357a7d24a93ebbe80bfda4f37a8d4",
-                "sha256:2d16b6196fb7a54aff6b5e3ecd00f7c0bab1b56eee39214b2b223a9d938c50af",
-                "sha256:2fd8053e1f8ff1844419842fd474fc359676b2e2a2b66b11cc59f4fa0a301315",
-                "sha256:31b265496e603985fad54d52d11970383e317d11e18e856971bdbb86af7242a4",
-                "sha256:3586e12d874ce2f1bc875a3ffba98732ebb12e18fb6d97be482bd62b56803281",
-                "sha256:47f5cf60bcb9fbc46011f75c9b45a8b5ad077ca352a78185bd3e7f1d294b98bb",
-                "sha256:490e52e99224858f154975db61c060686df8a6b3f0212a678e5d2e2ce24675c9",
-                "sha256:500d397ddf4bbf2ca42e198399ac13e7841956c72645513e8ddf243b31ad2128",
-                "sha256:52abae4c96b5da630a8b4247de5428f593465291e5b239f3f843a911a3cf0105",
-                "sha256:6579f9ba84a3d4f1807c4aab4be06f373017fc65fff43498885ac50a9b47a553",
-                "sha256:68e06f8b2248f6dc8b899c3e7ecf02c9f413aab622f4d6190df53a78b93d97a5",
-                "sha256:6c5439bfb35a89cac50e81c751317faea647b9a3ec11c039900cd6915831064d",
-                "sha256:72c3110228944019e5f27232296c5923398496b28be42535e3b2dc7297b6e8b6",
-                "sha256:72f649d93d4cc4d8cf79c91ebc25137c358718ad75f99e99e043325ea7d56100",
-                "sha256:7aaf07085c756f6cb1c692ee0d5a86c531703b6e8c9cae581b31b562c16b98ce",
-                "sha256:80fe92813d208ce8aa7d76da878bdc84b90809f79ccbad2a288e9bcbeac1d9bd",
-                "sha256:95545137fc56ce8c10de646074d242001a112a92de169986abd8c88c27566a05",
-                "sha256:97b6d21771da41497b81652d44191489296555b761684f82b7b544c49989110f",
-                "sha256:98cb63ca63cb61f594511c06218ab4394bf80388b3d66cd61d0b1f63ee0ea69f",
-                "sha256:9f3b4522148586d35e78313db4db0df4b759ddd7649ef70002b6c3767d0fdeb7",
-                "sha256:a09a9d4ec2b7887f7a088bbaacfd5c07160e746e3d47ec5e8050ae3b2a229e9f",
-                "sha256:b5050d681bcf5c9f2570b93bee5d3ec8ae4cf23158812f91ed57f7126df91762",
-                "sha256:bb47a548cea95b86494a26c89d153fd31122ed65255db5dcbc421a2d28eb3379",
-                "sha256:bc462d24500ba707e9cbdef436c16e5c8cbf29908278af053008d9f689f56dee",
-                "sha256:c2067b3bb0781f14059b112c9da5a91c80a600a97915b4f48b37f197895dd925",
-                "sha256:d154ed971a4cc04b93a6d5b47f37948d1f621f25de3e8fa0c26b2d44f24e3e8f",
-                "sha256:d5dcea1387331c905405b09cdbfb34611050cc52c865d71f2362f354faee1e9f",
-                "sha256:ee6e2963e92762923956fe5d3479b1fdc3b76c83f290aad131a2f98c3df0593e",
-                "sha256:fd0e5062f11cb3e730450a7d9f323f4051b532781026395c4323b8ad055523c4"
+                "sha256:011233e0c42a4a7836498e98c1acf5e744c96a67dd5032a6f666cc1fb97eab97",
+                "sha256:0f29d831e2151e0b7b39981756d201f7108d3d215896212ffe2e992d06bfe049",
+                "sha256:12875d118f21cf35604176872447cdb57b07126750a33748bac15e77f90f1f9c",
+                "sha256:14d4b1341ac07ae07eb2cc682f459bec932a380c3b122f5540432d8977e64eae",
+                "sha256:1c3c33ac69cf059bbb9d1a71eeaba76781b450bc307e2291f8a4764d779a6b28",
+                "sha256:1d19397351f73a88904ad1aee421e800fe4bbcd1aeee6435fb62d0a05ccd1030",
+                "sha256:253e8a302a96df6927310a9d44e6103055e8fb96a6822f8b7f514bb7ef77de56",
+                "sha256:2632d0f846b7c7600edf53c48f8f9f1e13e62f66a6dbc15191029d950bfed976",
+                "sha256:335ace1a22325395c4ea88e00ba3dc89ca029bd66bd5a3c382d53e44f0ccd77e",
+                "sha256:413ce0bbf9fc6278b2d63309dfeefe452835e1c78398efb431bab0672fe9274e",
+                "sha256:5100b45a4638e3c00e4d2320d3193bdabb2d75e79793af7c3eb139e4f569f16f",
+                "sha256:514ceac913076feefbeaf89771fd6febde78b0c4c1b23aaeab082c41c694e81b",
+                "sha256:528a2a692c65dd5cafc130de286030af251d2ee0483a5bf50c9348aefe834e8a",
+                "sha256:6295f6763749b89c994fcb6d8a7f7ce03c3992e695f89f00b741b4580b199b7e",
+                "sha256:6c8bc8238a7dfdaf7a75f5ec5a663f4173f8c367e5a39f87e720495e1eed75fa",
+                "sha256:718856856ba31f14f13ba885ff13874be7fefc53984d2832458f12c38205f7f7",
+                "sha256:7f7609a718b177bf171ac93cea9fd2ddc0e03e84d8fa4e887bdfc39671d46b00",
+                "sha256:80ca33961ced9c63358056bd08403ff866512038883e74f3a4bf88ad3eb66838",
+                "sha256:80fe64a6deb6fcfdf7b8386f2cf216d329be6f2781f7d90304351811fb591360",
+                "sha256:81c4b81611e3a3cb30e59b0cf05b888c675f97e3adb2c8672c3154047980726b",
+                "sha256:855c583f268edde09474b081e3ddcd5cf3b20c12f26e0d434e1386cc5d318e7a",
+                "sha256:9bfdb82cdfeccec50aad441afc332faf8606dfa5e8efd18a6692b5d6e79f00fd",
+                "sha256:a5d24e1d674dd9d72c66ad3ea9131322819ff86250b30dc5821cbafcfa0b96b4",
+                "sha256:a9f44cd7e162ac6191491d7249cceb02b8116b0f7e847ee33f739d7cb1ea1f70",
+                "sha256:b5b3f092fe345c03bca1e0b687dfbb39364b21ebb8ba90e3fa707374b7915204",
+                "sha256:b9618823bd237c0d2575283f2939655f54d51b4527ec3972907a927acbcc5bfc",
+                "sha256:cef9c85ccbe9bee00909758936ea841ef12035296c748aaceee535969e27d31b",
+                "sha256:d21237d0cd37acded35154e29aec853e945950321dd2ffd1a7d86fe686814669",
+                "sha256:d3c5c79ab7dfce6d88f1ba639b77e77a17ea33a01b07b99840d6ed08031cb2a7",
+                "sha256:d9d7942b624b04b895cb95af03a23407f17646815495ce4547f0e60e0b06f58e",
+                "sha256:db6d9fac65bd08cea7f3540b899977c6dee9edad959fa4eaf305940d9cbd861c",
+                "sha256:ede5af4a2702444a832a800b8eb7f0a7a1c0eed55b644642e049c98d589e5092",
+                "sha256:effb7749713d5317478bb3acb3f81d9d7c7f86726d41c1facca068a04cf5bb4c",
+                "sha256:f154d173286a5d1863637a7dcd8c3437bb557520b01bddb0be0258dcb72696b5",
+                "sha256:f25ed6e28ddf50de7e7ea99d7a976d6a9c415f03adcaac9c41ff6ff41b6d86ac"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==9.0.0"
+            "version": "==9.0.1"
         },
         "pipelineinfrastructure": {
             "editable": true,
@@ -606,43 +604,43 @@
         },
         "proto-plus": {
             "hashes": [
-                "sha256:3434eadaed845a337d6c488d2b7d055d733aaa231c0c0d4c778ec720bb91cf87",
-                "sha256:bdf45f0e0be71510eb2ec9db4da78afde7b5fb8b0a507a36340a9b6ce8e48e58"
+                "sha256:be7eb221f8b9e035c6622eca77cf341000edc8039676d027598f81318ef8faea",
+                "sha256:f61ddd048e740f57f23b7fd88f75764b1f881ca819054b3e2ccfcfc78cde7d5d"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.19.8"
+            "version": "==1.20.1"
         },
         "protobuf": {
             "hashes": [
-                "sha256:1291a0a7db7d792745c99d4657b4c5c4942695c8b1ac1bfb993a34035ec123f7",
-                "sha256:18c40a1b8721026a85187640f1786d52407dc9c1ba8ec38accb57a46e84015f6",
-                "sha256:1cb2ed66aac593adbf6dca4f07cd7ee7e2958b17bbc85b2cc8bc564ebeb258ec",
-                "sha256:2acd7ca329be544d1a603d5f13a4e34a3791c90d651ebaf130ba2e43ae5397c6",
-                "sha256:2cddcbcc222f3144765ccccdb35d3621dc1544da57a9aca7e1944c1a4fe3db11",
-                "sha256:397d82f1c58b76445469c8c06b8dee1ff67b3053639d054f52599a458fac9bc6",
-                "sha256:3bf3a07d17ba3511fe5fa916afb7351f482ab5dbab5afe71a7a384274a2cd550",
-                "sha256:3f80a3491eaca767cdd86cb8660dc778f634b44abdb0dffc9b2a8e8d0cd617d0",
-                "sha256:49677e5e9c7ea1245a90c2e8a00d304598f22ea3aa0628f0e0a530a9e70665fa",
-                "sha256:544fe9705189b249380fae07952d220c97f5c6c9372a6f936cc83a79601dcb70",
-                "sha256:6202df8ee8457cb00810c6e76ced480f22a1e4e02c899a14e7b6e6e1de09f938",
-                "sha256:84bf3aa3efb00dbe1c7ed55da0f20800b0662541e582d7e62b3e1464d61ed365",
-                "sha256:898bda9cd37ec0c781b598891e86435de80c3bfa53eb483a9dac5a11ec93e942",
-                "sha256:8ad761ef3be34c8bdc7285bec4b40372a8dad9e70cfbdc1793cd3cf4c1a4ce74",
-                "sha256:8ceaf5fdb72c8e1fcb7be9f2b3b07482ce058a3548180c0bdd5c7e4ac5e14165",
-                "sha256:a9401d96552befcc7311f5ef8f0fa7dba0ef5fd805466b158b141606cd0ab6a8",
-                "sha256:af7238849fa79285d448a24db686517570099739527a03c9c2971cce99cc5ae2",
-                "sha256:afa8122de8064fd577f49ae9eef433561c8ace97a0a7b969d56e8b1d39b5d177",
-                "sha256:b53519b2ebec70cfe24b4ddda21e9843f0918d7c3627a785393fb35d402ab8ad",
-                "sha256:c781402ed5396ab56358d7b866d78c03a77cbc26ba0598d8bb0ac32084b1a257",
-                "sha256:d975a6314fbf5c524d4981e24294739216b5fb81ef3c14b86fb4b045d6690907",
-                "sha256:df2ba379ee42427e8fcc6a0a76843bff6efb34ef5266b17f95043939b5e25b69",
-                "sha256:e54b8650e849ee8e95e481024bff92cf98f5ec61c7650cb838d928a140adcb63",
-                "sha256:e765e6dfbbb02c55e4d6d1145743401a84fc0b508f5a81b2c5a738cf86353139",
-                "sha256:ef02d112c025e83db5d1188a847e358beab3e4bbfbbaf10eaf69e67359af51b2",
-                "sha256:f6d4b5b7595a57e69eb7314c67bef4a3c745b4caf91accaf72913d8e0635111b"
+                "sha256:072fbc78d705d3edc7ccac58a62c4c8e0cec856987da7df8aca86e647be4e35c",
+                "sha256:09297b7972da685ce269ec52af761743714996b4381c085205914c41fcab59fb",
+                "sha256:16f519de1313f1b7139ad70772e7db515b1420d208cb16c6d7858ea989fc64a9",
+                "sha256:1c91ef4110fdd2c590effb5dca8fdbdcb3bf563eece99287019c4204f53d81a4",
+                "sha256:3112b58aac3bac9c8be2b60a9daf6b558ca3f7681c130dcdd788ade7c9ffbdca",
+                "sha256:36cecbabbda242915529b8ff364f2263cd4de7c46bbe361418b5ed859677ba58",
+                "sha256:4276cdec4447bd5015453e41bdc0c0c1234eda08420b7c9a18b8d647add51e4b",
+                "sha256:435bb78b37fc386f9275a7035fe4fb1364484e38980d0dd91bc834a02c5ec909",
+                "sha256:48ed3877fa43e22bcacc852ca76d4775741f9709dd9575881a373bd3e85e54b2",
+                "sha256:54a1473077f3b616779ce31f477351a45b4fef8c9fd7892d6d87e287a38df368",
+                "sha256:69da7d39e39942bd52848438462674c463e23963a1fdaa84d88df7fbd7e749b2",
+                "sha256:6cbc312be5e71869d9d5ea25147cdf652a6781cf4d906497ca7690b7b9b5df13",
+                "sha256:7bb03bc2873a2842e5ebb4801f5c7ff1bfbdf426f85d0172f7644fcda0671ae0",
+                "sha256:7ca7da9c339ca8890d66958f5462beabd611eca6c958691a8fe6eccbd1eb0c6e",
+                "sha256:835a9c949dc193953c319603b2961c5c8f4327957fe23d914ca80d982665e8ee",
+                "sha256:84123274d982b9e248a143dadd1b9815049f4477dc783bf84efe6250eb4b836a",
+                "sha256:8961c3a78ebfcd000920c9060a262f082f29838682b1f7201889300c1fbe0616",
+                "sha256:96bd766831596d6014ca88d86dc8fe0fb2e428c0b02432fd9db3943202bf8c5e",
+                "sha256:9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a",
+                "sha256:b38057450a0c566cbd04890a40edf916db890f2818e8682221611d78dc32ae26",
+                "sha256:bd95d1dfb9c4f4563e6093a9aa19d9c186bf98fa54da5252531cc0d3a07977e7",
+                "sha256:c1068287025f8ea025103e37d62ffd63fec8e9e636246b89c341aeda8a67c934",
+                "sha256:c438268eebb8cf039552897d78f402d734a404f1360592fef55297285f7f953f",
+                "sha256:cdc076c03381f5c1d9bb1abdcc5503d9ca8b53cf0a9d31a9f6754ec9e6c8af0f",
+                "sha256:f358aa33e03b7a84e0d91270a4d4d8f5df6921abe99a377828839e8ed0c04e07",
+                "sha256:f51d5a9f137f7a2cec2d326a74b6e3fc79d635d69ffe1b036d39fc7d75430d37"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.19.3"
+            "version": "==3.19.4"
         },
         "pyasn1": {
             "hashes": [
@@ -682,11 +680,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
-                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
+                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
+                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.6"
+            "version": "==3.0.7"
         },
         "pyproj": {
             "hashes": [
@@ -734,13 +732,13 @@
                 "sha256:6f41f1a34bc2e8df7bcc54f29b5f1db8e50b1e95221ecf7ec040952e845b1b1e",
                 "sha256:cf69357a037d7dd6a487631f1350fe8fca73ce6ea0ae75f2c86ae22545261225"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==2.8.3"
         },
         "rapidprotools": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/RapidProTools",
-            "ref": "d1a1601f5c2d0d5471f3108096ab24b26b4752ee"
+            "ref": "6c59f2bfd0973e57a3e803430eef8bf9a65b5667"
         },
         "requests": {
             "hashes": [
@@ -755,7 +753,7 @@
                 "sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17",
                 "sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==4.8"
         },
         "scikit-learn": {
@@ -798,46 +796,40 @@
         },
         "scipy": {
             "hashes": [
-                "sha256:033ce76ed4e9f62923e1f8124f7e2b0800db533828c853b402c7eec6e9465d80",
-                "sha256:173308efba2270dcd61cd45a30dfded6ec0085b4b6eb33b5eb11ab443005e088",
-                "sha256:21b66200cf44b1c3e86495e3a436fc7a26608f92b8d43d344457c54f1c024cbc",
-                "sha256:2c56b820d304dffcadbbb6cbfbc2e2c79ee46ea291db17e288e73cd3c64fefa9",
-                "sha256:304dfaa7146cffdb75fbf6bb7c190fd7688795389ad060b970269c8576d038e9",
-                "sha256:3f78181a153fa21c018d346f595edd648344751d7f03ab94b398be2ad083ed3e",
-                "sha256:4d242d13206ca4302d83d8a6388c9dfce49fc48fdd3c20efad89ba12f785bf9e",
-                "sha256:5d1cc2c19afe3b5a546ede7e6a44ce1ff52e443d12b231823268019f608b9b12",
-                "sha256:5f2cfc359379c56b3a41b17ebd024109b2049f878badc1e454f31418c3a18436",
-                "sha256:65bd52bf55f9a1071398557394203d881384d27b9c2cad7df9a027170aeaef93",
-                "sha256:7edd9a311299a61e9919ea4192dd477395b50c014cdc1a1ac572d7c27e2207fa",
-                "sha256:8499d9dd1459dc0d0fe68db0832c3d5fc1361ae8e13d05e6849b358dc3f2c279",
-                "sha256:866ada14a95b083dd727a845a764cf95dd13ba3dc69a16b99038001b05439709",
-                "sha256:87069cf875f0262a6e3187ab0f419f5b4280d3dcf4811ef9613c605f6e4dca95",
-                "sha256:93378f3d14fff07572392ce6a6a2ceb3a1f237733bd6dcb9eb6a2b29b0d19085",
-                "sha256:95c2d250074cfa76715d58830579c64dff7354484b284c2b8b87e5a38321672c",
-                "sha256:ab5875facfdef77e0a47d5fd39ea178b58e60e454a4c85aa1e52fcb80db7babf",
-                "sha256:b0e0aeb061a1d7dcd2ed59ea57ee56c9b23dd60100825f98238c06ee5cc4467e",
-                "sha256:b78a35c5c74d336f42f44106174b9851c783184a85a3fe3e68857259b37b9ffb",
-                "sha256:c9e04d7e9b03a8a6ac2045f7c5ef741be86727d8f49c45db45f244bdd2bcff17",
-                "sha256:ca36e7d9430f7481fc7d11e015ae16fbd5575615a8e9060538104778be84addf",
-                "sha256:ceebc3c4f6a109777c0053dfa0282fddb8893eddfb0d598574acfb734a926168",
-                "sha256:e2c036492e673aad1b7b0d0ccdc0cb30a968353d2c4bf92ac8e73509e1bf212c",
-                "sha256:eb326658f9b73c07081300daba90a8746543b5ea177184daed26528273157294",
-                "sha256:eb7ae2c4dbdb3c9247e07acc532f91077ae6dbc40ad5bd5dca0bb5a176ee9bda",
-                "sha256:edad1cf5b2ce1912c4d8ddad20e11d333165552aba262c882e28c78bbc09dbf6",
-                "sha256:eef93a446114ac0193a7b714ce67659db80caf940f3232bad63f4c7a81bc18df",
-                "sha256:f7eaea089345a35130bc9a39b89ec1ff69c208efa97b3f8b25ea5d4c41d88094",
-                "sha256:f99d206db1f1ae735a8192ab93bd6028f3a42f6fa08467d37a14eb96c9dd34a3"
+                "sha256:011d4386b53b933142f58a652aa0f149c9b9242abd4f900b9f4ea5fbafc86b89",
+                "sha256:16e09ef68b352d73befa8bcaf3ebe25d3941fe1a58c82909d5589856e6bc8174",
+                "sha256:31d4f2d6b724bc9a98e527b5849b8a7e589bf1ea630c33aa563eda912c9ff0bd",
+                "sha256:38aa39b6724cb65271e469013aeb6f2ce66fd44f093e241c28a9c6bc64fd79ed",
+                "sha256:3d573228c10a3a8c32b9037be982e6440e411b443a6267b067cac72f690b8d56",
+                "sha256:3d9dd6c8b93a22bf9a3a52d1327aca7e092b1299fb3afc4f89e8eba381be7b59",
+                "sha256:559a8a4c03a5ba9fe3232f39ed24f86457e4f3f6c0abbeae1fb945029f092720",
+                "sha256:5e73343c5e0d413c1f937302b2e04fb07872f5843041bcfd50699aef6e95e399",
+                "sha256:723b9f878095ed994756fa4ee3060c450e2db0139c5ba248ee3f9628bd64e735",
+                "sha256:87b01c7d5761e8a266a0fbdb9d88dcba0910d63c1c671bdb4d99d29f469e9e03",
+                "sha256:8f4d059a97b29c91afad46b1737274cb282357a305a80bdd9e8adf3b0ca6a3f0",
+                "sha256:92b2c2af4183ed09afb595709a8ef5783b2baf7f41e26ece24e1329c109691a7",
+                "sha256:937d28722f13302febde29847bbe554b89073fbb924a30475e5ed7b028898b5f",
+                "sha256:a279e27c7f4566ef18bab1b1e2c37d168e365080974758d107e7d237d3f0f484",
+                "sha256:ad5be4039147c808e64f99c0e8a9641eb5d2fa079ff5894dcd8240e94e347af4",
+                "sha256:ae3e327da323d82e918e593460e23babdce40d7ab21490ddf9fc06dec6b91a18",
+                "sha256:bb7088e89cd751acf66195d2f00cf009a1ea113f3019664032d9075b1e727b6c",
+                "sha256:c17a1878d00a5dd2797ccd73623ceca9d02375328f6218ee6d921e1325e61aff",
+                "sha256:c2bae431d127bf0b1da81fc24e4bba0a84d058e3a96b9dd6475dfcb3c5e8761e",
+                "sha256:de2e80ee1d925984c2504812a310841c241791c5279352be4707cdcd7c255039",
+                "sha256:e6f0cd9c0bd374ef834ee1e0f0999678d49dcc400ea6209113d81528958f97c7",
+                "sha256:f3720d0124aced49f6f2198a6900304411dbbeed12f56951d7c66ebef05e3df6",
+                "sha256:f4a6d3b9f9797eb2d43938ac2c5d96d02aed17ef170c8b38f11798717523ddba"
             ],
-            "markers": "python_version < '3.11' and python_version >= '3.7'",
-            "version": "==1.7.3"
+            "markers": "python_version < '3.11' and python_version >= '3.8'",
+            "version": "==1.8.0"
         },
         "setuptools": {
             "hashes": [
-                "sha256:2404879cda71495fc4d5cbc445ed52fdaddf352b36e40be8dcc63147cb4edabe",
-                "sha256:68eb94073fc486091447fcb0501efd6560a0e5a1839ba249e5ff3c4c93f05f90"
+                "sha256:716f9d20b4c3513d1720245eb1dac009b40c9694c88e940e54b67b8b65d09493",
+                "sha256:d181db00651bce5268b8f559795053d5e8f645e4dbafac6d262b22d7e72e19eb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==60.5.0"
+            "version": "==60.9.0"
         },
         "shapely": {
             "hashes": [
@@ -876,11 +868,11 @@
         },
         "threadpoolctl": {
             "hashes": [
-                "sha256:4fade5b3b48ae4b1c30f200b28f39180371104fccc642e039e0f2435ec8cc211",
-                "sha256:d03115321233d0be715f0d3a5ad1d6c065fe425ddc2d671ca8e45e9fd5d7a52a"
+                "sha256:8b99adda265feb6773280df41eece7b2e6561b772d21ffd52e372f999024907b",
+                "sha256:a335baacfaa4400ae1f0d8e3a58d6674d2f8828e3716bb2802c44955ad391380"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.0"
+            "version": "==3.1.0"
         },
         "uritemplate": {
             "hashes": [
@@ -895,7 +887,7 @@
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.8"
         }
     },

--- a/configurations/s02_pipeline_configuration.py
+++ b/configurations/s02_pipeline_configuration.py
@@ -211,7 +211,9 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
         sync_config=EngagementDBToRapidProConfiguration(
         consent_withdrawn_dataset=DatasetConfiguration(
                 engagement_db_datasets=[], #TODO: to be updated
-                rapid_pro_contact_field=ContactField(label="leap s02 kalobeyei consent withdrawn" ) # Rapidpro contact field display label
+                rapid_pro_contact_field=ContactField(label="leap s02 kalobeyei consent withdrawn" ) # Rapidpro contact_field
+                                                                        # display label. RP will use this to create a new contact_field
+                                                                        # if it does not exist.
             ),
         weekly_advert_contact_field=ContactField(label="leap s02 weekly advert contacts"),
         sync_advert_contacts = True,

--- a/configurations/s02_pipeline_configuration.py
+++ b/configurations/s02_pipeline_configuration.py
@@ -213,6 +213,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 engagement_db_datasets=[], #TODO: to be updated
                 rapid_pro_contact_field=ContactField(key="leap_s02_kalobeyei_consent_withdrawn" )
             ),
+        weekly_advert_contact_field=ContactField(key="wusc_leap_advert_contacts_test"),
         sync_advert_contacts = True,
         )
     ),

--- a/configurations/s02_pipeline_configuration.py
+++ b/configurations/s02_pipeline_configuration.py
@@ -237,7 +237,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e01_raw",
                 dataset_name = "Leap_s02e01",
-                rapid_pro_non_relevant_label = "leap s02e01 non relevant contacts", # should be less than 36 char, non-numeric, with no special characters
+                rapid_pro_non_relevant_field=ContactField(label = "leap s02e01 non relevant contacts"), # should be less than 36 char, non-numeric, with no special characters
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e01"),
@@ -250,7 +250,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e02_raw",
                 dataset_name = "Leap_s02e02",
-                rapid_pro_non_relevant_label = "leap s02e02 non relevant contacts",
+                rapid_pro_non_relevant_field=ContactField(label="leap s02e02 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e02"),
@@ -263,7 +263,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e03_raw",
                 dataset_name = "Leap_s02e03",
-                rapid_pro_non_relevant_label = "leap s02e03 non relevant contacts",
+                rapid_pro_non_relevant_field=ContactField(label = "leap s02e03 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e03"),
@@ -276,7 +276,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e04_raw",
                 dataset_name = "Leap_s02e04",
-                rapid_pro_non_relevant_label = "leap s02e04 non relevant contacts",
+                rapid_pro_non_relevant_field=ContactField(label = "leap s02e04 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e04"),
@@ -289,7 +289,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e05_raw",
                 dataset_name = "Leap_s02e05",
-                rapid_pro_non_relevant_label = "leap s02e05 non relevant contacts",
+                rapid_pro_non_relevant_field=ContactField(label="leap s02e04 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e05"),
@@ -302,7 +302,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e06_raw",
                 dataset_name = "Leap_s02e06",
-                rapid_pro_non_relevant_label = "leap s02e06 non relevant contacts",
+                rapid_pro_non_relevant_field=ContactField(label="leap s02e06 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e06"),
@@ -315,7 +315,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e07_raw",
                 dataset_name = "Leap_s02e07",
-                rapid_pro_non_relevant_label = "leap s02e07 non relevant contacts",
+                rapid_pro_non_relevant_field=ContactField(label="leap s02e07 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e07"),
@@ -328,7 +328,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e08_raw",
                 dataset_name = "Leap_s02e08",
-                rapid_pro_non_relevant_label = "leap s02e08 non relevant contacts",
+                rapid_pro_non_relevant_field=ContactField(label="leap s02e08 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e08"),

--- a/configurations/s02_pipeline_configuration.py
+++ b/configurations/s02_pipeline_configuration.py
@@ -211,9 +211,9 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
         sync_config=EngagementDBToRapidProConfiguration(
         consent_withdrawn_dataset=DatasetConfiguration(
                 engagement_db_datasets=[], #TODO: to be updated
-                rapid_pro_contact_field=ContactField(key="leap_s02_kalobeyei_consent_withdrawn" )
+                rapid_pro_contact_field=ContactField(label="leap s02 kalobeyei consent withdrawn" ) # Rapidpro contact field display label
             ),
-        weekly_advert_contact_field=ContactField(key="wusc_leap_advert_contacts_test"),
+        weekly_advert_contact_field=ContactField(label="leap s02 weekly advert contacts"),
         sync_advert_contacts = True,
         )
     ),
@@ -235,6 +235,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e01_raw",
                 dataset_name = "Leap_s02e01",
+                rapid_pro_non_relevant_label = "leap s02e01 non relevant contacts", # should be less than 36 char, non-numeric, with no special characters
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e01"),
@@ -247,6 +248,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e02_raw",
                 dataset_name = "Leap_s02e02",
+                rapid_pro_non_relevant_label = "leap s02e02 non relevant contacts",
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e02"),
@@ -259,6 +261,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e03_raw",
                 dataset_name = "Leap_s02e03",
+                rapid_pro_non_relevant_label = "leap s02e03 non relevant contacts",
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e03"),
@@ -271,6 +274,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e04_raw",
                 dataset_name = "Leap_s02e04",
+                rapid_pro_non_relevant_label = "leap s02e04 non relevant contacts",
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e04"),
@@ -283,6 +287,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e05_raw",
                 dataset_name = "Leap_s02e05",
+                rapid_pro_non_relevant_label = "leap s02e05 non relevant contacts",
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e05"),
@@ -295,6 +300,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e06_raw",
                 dataset_name = "Leap_s02e06",
+                rapid_pro_non_relevant_label = "leap s02e06 non relevant contacts",
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e06"),
@@ -307,6 +313,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e07_raw",
                 dataset_name = "Leap_s02e07",
+                rapid_pro_non_relevant_label = "leap s02e07 non relevant contacts",
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e07"),
@@ -319,6 +326,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e08_raw",
                 dataset_name = "Leap_s02e08",
+                rapid_pro_non_relevant_label = "leap s02e08 non relevant contacts",
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e08"),

--- a/configurations/s02_pipeline_configuration.py
+++ b/configurations/s02_pipeline_configuration.py
@@ -209,14 +209,14 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
             token_file_url="gs://avf-credentials/wusc-leap-kalobeyei-textit-token.txt"
         ),
         sync_config=EngagementDBToRapidProConfiguration(
-        consent_withdrawn_dataset=DatasetConfiguration(
+            consent_withdrawn_dataset=DatasetConfiguration(
                 engagement_db_datasets=[], #TODO: to be updated
-                rapid_pro_contact_field=ContactField(label="leap s02 kalobeyei consent withdrawn" ) # Rapidpro contact_field
-                                                                        # display label. RP will use this to create a new contact_field
-                                                                        # if it does not exist.
+                rapid_pro_contact_field=ContactField(key="leap_s02_kalobeyei_consent_withdrawn",
+                                                     label="leap s02 kalobeyei consent withdrawn" )
             ),
-        weekly_advert_contact_field=ContactField(label="leap s02 weekly advert contacts"),
-        sync_advert_contacts = True,
+            weekly_advert_contact_field=ContactField(key="leap_s02_weekly_advert_contacts",
+                                                     label="leap s02 weekly advert contacts"),
+            sync_advert_contacts = True,
         )
     ),
     analysis=AnalysisConfiguration(
@@ -237,7 +237,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e01_raw",
                 dataset_name = "Leap_s02e01",
-                rapid_pro_non_relevant_field=ContactField(label = "leap s02e01 non relevant contacts"), # should be less than 36 char, non-numeric, with no special characters
+                rapid_pro_non_relevant_field=ContactField(key="leap_s02e01_non_relevant_contacts",
+                                                          label = "leap s02e01 non relevant contacts"), # label should be less than 36 char, non-numeric, with no special characters
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e01"),
@@ -250,7 +251,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e02_raw",
                 dataset_name = "Leap_s02e02",
-                rapid_pro_non_relevant_field=ContactField(label="leap s02e02 non relevant contacts"),
+                rapid_pro_non_relevant_field=ContactField(key="leap_s02e02_non_relevant_contacts",
+                                                          label="leap s02e02 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e02"),
@@ -263,7 +265,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e03_raw",
                 dataset_name = "Leap_s02e03",
-                rapid_pro_non_relevant_field=ContactField(label = "leap s02e03 non relevant contacts"),
+                rapid_pro_non_relevant_field=ContactField(key="leap_s02e03_non_relevant_contacts",
+                                                          label = "leap s02e03 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e03"),
@@ -276,7 +279,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e04_raw",
                 dataset_name = "Leap_s02e04",
-                rapid_pro_non_relevant_field=ContactField(label = "leap s02e04 non relevant contacts"),
+                rapid_pro_non_relevant_field=ContactField(key="leap_s02e04_non_relevant_contacts",
+                                                          label = "leap s02e04 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e04"),
@@ -289,7 +293,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e05_raw",
                 dataset_name = "Leap_s02e05",
-                rapid_pro_non_relevant_field=ContactField(label="leap s02e04 non relevant contacts"),
+                rapid_pro_non_relevant_field=ContactField(key="leap_s02e05_non_relevant_contacts",
+                                                          label="leap s02e05 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e05"),
@@ -302,7 +307,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e06_raw",
                 dataset_name = "Leap_s02e06",
-                rapid_pro_non_relevant_field=ContactField(label="leap s02e06 non relevant contacts"),
+                rapid_pro_non_relevant_field=ContactField(key="leap_s02e06_non_relevant_contacts",
+                                                          label="leap s02e06 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e06"),
@@ -315,7 +321,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e07_raw",
                 dataset_name = "Leap_s02e07",
-                rapid_pro_non_relevant_field=ContactField(label="leap s02e07 non relevant contacts"),
+                rapid_pro_non_relevant_field=ContactField(key="leap_s02e07_non_relevant_contacts",
+                                                          label="leap s02e07 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e07"),
@@ -328,7 +335,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 dataset_type=DatasetTypes.RESEARCH_QUESTION_ANSWER,
                 raw_dataset="s02e08_raw",
                 dataset_name = "Leap_s02e08",
-                rapid_pro_non_relevant_field=ContactField(label="leap s02e08 non relevant contacts"),
+                rapid_pro_non_relevant_field=ContactField(key="leap_s02e08_non_relevant_contacts",
+                                                          label="leap s02e08 non relevant contacts"),
                 coding_configs=[
                     CodingConfiguration(
                         code_scheme=load_code_scheme("s02e08"),

--- a/src/engagement_db_to_analysis/configuration.py
+++ b/src/engagement_db_to_analysis/configuration.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from core_data_modules.data_models import CodeScheme
+from src.engagement_db_to_rapid_pro.configuration import ContactField
 
 
 @dataclass
@@ -37,7 +38,7 @@ class AnalysisDatasetConfiguration:
     raw_dataset: str
     dataset_name: str
     coding_configs: [CodingConfiguration]
-    rapid_pro_non_relevant_label: str = None
+    rapid_pro_non_relevant_field: ContactField = None
 
 
 @dataclass

--- a/src/engagement_db_to_analysis/configuration.py
+++ b/src/engagement_db_to_analysis/configuration.py
@@ -37,6 +37,7 @@ class AnalysisDatasetConfiguration:
     raw_dataset: str
     dataset_name: str
     coding_configs: [CodingConfiguration]
+    rapid_pro_non_relevant_label: str = None
 
 
 @dataclass

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -32,8 +32,8 @@ def _generate_weekly_advert_and_opt_out_uuids(participants_by_column, analysis_c
     being needed to advertise to if they are in the participants_by_column or
     a listening group and haven't opted out.
 
-    :param participants_by_column: Participants column view TracedData object to generate the uuids from.
-    :type participants_by_column: core_data_modules.traced_data.TracedData
+    :param participants_by_column: list of participants column view TracedData object to generate the uuids from.
+    :type participants_by_column: list of core_data_modules.traced_data.TracedData
     :param analysis_config: Configuration for the export.
     :type analysis_config: src.engagement_db_to_analysis.configuration.AnalysisConfiguration
     :param google_cloud_credentials_file_path: Path to the Google Cloud service account credentials file to use to
@@ -85,8 +85,8 @@ def _generate_non_relevant_advert_uuids_by_dataset(participants_by_column, datas
     '''
     Generates non relevant advert UUIDS for each episode.
 
-    :param participants_by_column: Participants column view Traced Data object to generate the uuids from.
-    :type participants_by_column: core_data_modules.traced_data.TracedData
+    :param participants_by_column: list of participants column view Traced Data object to generate the uuids from.
+    :type participants_by_column: list of core_data_modules.traced_data.TracedData
     :param dataset_configurations: Configuration for the export.
     :type dataset_configurations: src.engagement_db_to_analysis.configuration.AnalysisConfiguration.dataset_configurations
     :return non_relevant_uuids : A map of dataset_name -> uuids who sent messages labelled with non relevant themes.

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -94,12 +94,12 @@ def _generate_non_relevant_advert_uuids_by_dataset(participants_by_column, datas
     non_relevant_uuids = dict()
     for analysis_dataset_config in dataset_configurations:
         if analysis_dataset_config.dataset_type == DatasetTypes.DEMOGRAPHIC or\
-                analysis_dataset_config.rapid_pro_nc_group_label is None:
+                analysis_dataset_config.rapid_pro_non_relevant_label is None:
             continue
 
         assert analysis_dataset_config.dataset_type == DatasetTypes.RESEARCH_QUESTION_ANSWER
 
-        non_relevant_uuids[analysis_dataset_config.rapid_pro_nc_group_label] = set()
+        non_relevant_uuids[analysis_dataset_config.rapid_pro_non_relevant_label] = set()
         for participant_td in participants_by_column:
             if participant_td["consent_withdrawn"] == Codes.TRUE:
                 continue
@@ -120,7 +120,7 @@ def _generate_non_relevant_advert_uuids_by_dataset(participants_by_column, datas
                     for code in codes:
                         if code.string_value in ["showtime_question", "greeting", "opt_in",
                                                  "about_conversation", "gratitude", "question", "NC"]:
-                            non_relevant_uuids[analysis_dataset_config.rapid_pro_nc_group_label].add(participant_td["participant_uuid"])
+                            non_relevant_uuids[analysis_dataset_config.rapid_pro_non_relevant_label].add(participant_td["participant_uuid"])
 
     return non_relevant_uuids
 

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -93,8 +93,7 @@ def _generate_non_relevant_advert_uuids_by_dataset(participants_by_column, datas
 
     non_relevant_uuids = dict()
     for analysis_dataset_config in dataset_configurations:
-        if analysis_dataset_config.dataset_type == DatasetTypes.DEMOGRAPHIC or\
-                analysis_dataset_config.rapid_pro_non_relevant_label is None:
+        if analysis_dataset_config.rapid_pro_non_relevant_label is None:
             continue
 
         assert analysis_dataset_config.dataset_type == DatasetTypes.RESEARCH_QUESTION_ANSWER

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -174,7 +174,7 @@ def _ensure_contact_field_exists(workspace_contact_fields, target_contact_field_
 
 
 @time_it
-def _sync_advert_contacts_fields_to_rapidpro(cache, target_uuids, advert_contact_field_name, uuid_table, rapid_pro):
+def _sync_advert_contacts_fields_to_rapid_pro(cache, target_uuids, advert_contact_field_name, uuid_table, rapid_pro):
     '''
     Updates the advert contact field for the target urns.
 
@@ -266,14 +266,14 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
         pipeline_config.rapid_pro_target.sync_config.consent_withdrawn_dataset.rapid_pro_contact_field.label
     consent_withdrawn_contact_field_key = _ensure_contact_field_exists(workspace_contact_fields,
                                                                        consent_withdrawn_contact_field_label, rapid_pro)
-    _sync_advert_contacts_fields_to_rapidpro(cache, opt_out_uuids, consent_withdrawn_contact_field_key, uuid_table,
+    _sync_advert_contacts_fields_to_rapid_pro(cache, opt_out_uuids, consent_withdrawn_contact_field_key, uuid_table,
                                              rapid_pro)
 
     log.info(f'Syncing weekly advert contacts to rapid pro...')
     weekly_advert_contact_field_label = pipeline_config.rapid_pro_target.sync_config.weekly_advert_contact_field.label
     weekly_advert_contact_field_key = _ensure_contact_field_exists(workspace_contact_fields,
                                                                    weekly_advert_contact_field_label, rapid_pro)
-    _sync_advert_contacts_fields_to_rapidpro(cache, weekly_advert_uuids, weekly_advert_contact_field_key, uuid_table,
+    _sync_advert_contacts_fields_to_rapid_pro(cache, weekly_advert_uuids, weekly_advert_contact_field_key, uuid_table,
                                              rapid_pro)
 
     #Update  dataset non relevant groups to rapid_pro
@@ -284,5 +284,5 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
     for dataset_rapid_pro_non_relevant_label, non_relevant_uuids in non_relevant_uuids.items():
         dataset_rapid_pro_non_relevant_key = _ensure_contact_field_exists(workspace_contact_fields,
                                                                           dataset_rapid_pro_non_relevant_label, rapid_pro)
-        _sync_advert_contacts_fields_to_rapidpro(cache, non_relevant_uuids, dataset_rapid_pro_non_relevant_key,
+        _sync_advert_contacts_fields_to_rapid_pro(cache, non_relevant_uuids, dataset_rapid_pro_non_relevant_key,
                                                  uuid_table, rapid_pro)

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -23,7 +23,7 @@ def time_it(func):
 
 
 def _generate_weekly_advert_and_opt_out_uuids(participants_by_column, analysis_config,
-                                     google_cloud_credentials_file_path, membership_group_dir_path):
+                                              google_cloud_credentials_file_path, membership_group_dir_path):
     '''
     Generates sets of weekly advert and  opt_out UUIDs to advertise to. A participant is considered to have opted out
     if they are marked as 'consent_withdrawn' in the participants_by_column dataset. A participant is considered as
@@ -217,7 +217,7 @@ def _sync_advert_contacts_fields_to_rapidpro(cache, target_uuids, advert_contact
 
 
 def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipeline_config, rapid_pro,
-                         google_cloud_credentials_file_path, membership_group_dir_path, cache_path):
+                                     google_cloud_credentials_file_path, membership_group_dir_path, cache_path):
     '''
     Syncs advert contacts to rapid_pro by:
       1. Updating project rapid_pro consent field as 'yes' for urns considered to have opted out A participant is
@@ -253,8 +253,8 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
         cache = AnalysisCache(f"{cache_path}")
 
     opt_out_uuids, weekly_advert_uuids = _generate_weekly_advert_and_opt_out_uuids(
-                                                participants_by_column, pipeline_config.analysis,
-                                                google_cloud_credentials_file_path, membership_group_dir_path
+        participants_by_column, pipeline_config.analysis,
+        google_cloud_credentials_file_path, membership_group_dir_path
     )
 
     # Get workspace contact fields to check whether our target contact field exists
@@ -272,17 +272,17 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
     log.info(f'Syncing weekly advert contacts to rapid pro...')
     weekly_advert_contact_field_label = pipeline_config.rapid_pro_target.sync_config.weekly_advert_contact_field.label
     weekly_advert_contact_field_key = _ensure_contact_field_exists(workspace_contact_fields,
-                                                                       weekly_advert_contact_field_label, rapid_pro)
+                                                                   weekly_advert_contact_field_label, rapid_pro)
     _sync_advert_contacts_fields_to_rapidpro(cache, weekly_advert_uuids, weekly_advert_contact_field_key, uuid_table,
                                              rapid_pro)
 
     #Update  dataset non relevant groups to rapid_pro
     log.info(f'Syncing contacts who sent non relevant messages for each episode...')
     non_relevant_uuids = _generate_non_relevant_advert_uuids_by_dataset(participants_by_column,
-                                                                pipeline_config.analysis.dataset_configurations)
+                                                                        pipeline_config.analysis.dataset_configurations)
 
     for dataset_rapid_pro_non_relevant_label, non_relevant_uuids in non_relevant_uuids.items():
         dataset_rapid_pro_non_relevant_key = _ensure_contact_field_exists(workspace_contact_fields,
-                                                                       dataset_rapid_pro_non_relevant_label, rapid_pro)
+                                                                          dataset_rapid_pro_non_relevant_label, rapid_pro)
         _sync_advert_contacts_fields_to_rapidpro(cache, non_relevant_uuids, dataset_rapid_pro_non_relevant_key,
                                                  uuid_table, rapid_pro)

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -185,6 +185,7 @@ def _sync_advert_contacts_fields_to_rapid_pro(cache, target_uuids, advert_contac
 
     else:
         assert len(uuids_to_sync) == 0
+        log.info("Found 0 uuids to sync in this run skipping...")
 
 
 def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipeline_config, rapid_pro,

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -98,7 +98,7 @@ def _generate_non_relevant_advert_uuids_by_dataset(participants_by_column, datas
 
         assert analysis_dataset_config.dataset_type == DatasetTypes.RESEARCH_QUESTION_ANSWER
 
-        non_relevant_uuids[analysis_dataset_config.rapid_pro_non_relevant_label] = set()
+        non_relevant_uuids[analysis_dataset_config.rapid_pro_non_relevant_field.label] = set()
         for participant_td in participants_by_column:
             if participant_td["consent_withdrawn"] == Codes.TRUE:
                 continue
@@ -228,7 +228,7 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
          non relevant themes and have not opted out.
 
     :param participants_by_column: Participants column view Traced Data object to generate the uuids from.
-    :type participants_by_column: List of core_data_modules.traced_data.TracedData
+    :type participants_by_column: list of core_data_modules.traced_data.TracedData
     :param uuid_table: UUID table to use to de-identify contact urns.
     :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable.
     :param pipeline_config: Pipeline configuration to derive configurations needed for the sync functions.

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -251,7 +251,7 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
     :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable.
     :param pipeline_config: Pipeline configuration to derive configurations needed for the sync functions.
     :type pipeline_config: PipelineConfiguration.
-    :param rapid_pro: Rapid Pro client to sync the groups to.
+    :param rapid_pro: Rapid Pro client to sync the contact fields to.
     :type rapid_pro: rapid_pro_tools.rapid_pro.RapidProClient
     :param google_cloud_credentials_file_path: Path to the Google Cloud service account credentials file to use to
                                                access the credentials bucket.

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -128,8 +128,8 @@ def _convert_uuids_to_urns(uuids_group, uuid_table):
     """
     Converts a list of UUIDs to their respective rapid_pro urns.
 
-    :param uuids_group: list of participant UUIDs to convert.
-    :type uuids_group: list of participant UUIDs.
+    :param uuids_group: set of participant UUIDs to convert.
+    :type uuids_group: set of participant UUIDs.
     :param uuid_table: UUID table to use to de-identify contact urns.
     :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable
     :return urns: a set of de-identified urn.
@@ -143,25 +143,6 @@ def _convert_uuids_to_urns(uuids_group, uuid_table):
 
     return urns
 
-
-def _get_uuids_to_sync(target_uuids, synced_uuids):
-    '''
-    Generates uuids from target group, to sync in the current pipeline run, based on previously synced uuids in cache.
-
-    :param target_uuids: Set containing all uuids for the target context e.g opt_out uuids
-    :type target_uuids: set of str
-    :param synced_uuids: List containing all uuids synced in previous pipeline run.
-    :type synced_uuids: list of str
-    :return uuids_to_sync: A set of uuids to sync in the current pipeline run.
-    :rtype uuids_to_sync: set of str
-    '''
-
-    uuids_to_sync = set()
-    for uid in target_uuids:
-        if uid not in synced_uuids:
-            uuids_to_sync.add(uid)
-
-    return uuids_to_sync
 
 def _ensure_contact_field_exists(workspace_contact_fields, target_contact_field_label, rapid_pro):
     """
@@ -215,7 +196,7 @@ def _sync_advert_contacts_fields_to_rapidpro(cache, target_uuids, advert_contact
         synced_uuids.extend(previously_synced_non_relevant_uuids)
 
     # If cache is available, check for uuids to sync in the current pipeline run.
-    uuids_to_sync = _get_uuids_to_sync(target_uuids, synced_uuids)
+    uuids_to_sync = target_uuids - set(synced_uuids)
 
     if len(uuids_to_sync) > 0:
         log.info(f'Syncing {len(uuids_to_sync)} urns in this run ')

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -13,17 +13,6 @@ CONSENT_WITHDRAWN_KEY = "consent_withdrawn"
 
 #TODO move this to engagement db to rapid_pro sync once we support syncing imputed labels to db
 
-import time #Todo remove before merging
-def time_it(func):
-    def wrapper(*args, **kwargs):
-        start = time.time()
-        result = func(*args,**kwargs)
-        end = time.time()
-        print(func.__name__ +" took " + str((end-start)*1000) + " mil sec")
-        return result
-    return wrapper
-
-
 def _generate_weekly_advert_and_opt_out_uuids(participants_by_column, analysis_config,
                                               google_cloud_credentials_file_path, membership_group_dir_path):
     '''
@@ -155,7 +144,7 @@ def _ensure_contact_field_exists(workspace_contact_fields, contact_field, rapid_
     if contact_field.key not in workspace_contact_field_keys:
         rapid_pro.create_field(field_id=contact_field.key, label=contact_field.label)
 
-@time_it
+
 def _sync_advert_contacts_fields_to_rapid_pro(cache, target_uuids, advert_contact_field_key, uuid_table, rapid_pro):
     '''
     Updates the advert contact field for the target urns.
@@ -195,7 +184,7 @@ def _sync_advert_contacts_fields_to_rapid_pro(cache, target_uuids, advert_contac
                 cache.set_synced_uuids(advert_contact_field_key, synced_uuids)
 
     else:
-        log.info(f'Found {len(uuids_to_sync)} uuids to sync in this run skipping...')
+        assert len(uuids_to_sync) == 0
 
 
 def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipeline_config, rapid_pro,

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -144,6 +144,7 @@ def _convert_uuids_to_urns(uuids_group, uuid_table):
     return urns
 
 
+#Todo: standardize and move to rapidpro tools
 def _ensure_contact_field_exists(workspace_contact_fields, target_contact_field_label, rapid_pro):
     """
     Checks if a workspace contains the target contact field, creates one otherwise.
@@ -170,6 +171,7 @@ def _ensure_contact_field_exists(workspace_contact_fields, target_contact_field_
         target_contact_field_key = rapid_pro.create_field(label=target_contact_field_label).key
 
     return target_contact_field_key
+
 
 @time_it
 def _sync_advert_contacts_fields_to_rapidpro(cache, target_uuids, advert_contact_field_name, uuid_table, rapid_pro):
@@ -255,7 +257,7 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
                                                 google_cloud_credentials_file_path, membership_group_dir_path
     )
 
-    # Get workspace contact fields for checking in whether our target contact fields exists
+    # Get workspace contact fields to check whether our target contact field exists
     workspace_contact_fields = rapid_pro.get_fields()
 
     log.info(f'Syncing consent_withdrawn contact_fields in rapidpro... ')

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -11,7 +11,7 @@ log = Logger(__name__)
 
 CONSENT_WITHDRAWN_KEY = "consent_withdrawn"
 
-import time
+import time #Todo remove before merging
 def time_it(func):
     def wrapper(*args, **kwargs):
         start = time.time()
@@ -184,7 +184,7 @@ def _sync_advert_contacts_fields_to_rapidpro(cache, target_uuids, advert_contact
     synced_uuids = []
     if cache is not None:
         synced_dataset_nc_uuids = cache.get_synced_uuids(advert_contact_field_name)
-        log.info(f'Found {len(synced_dataset_nc_uuids)} uuids whose {advert_contact_field_name} was synced in previous '
+        log.info(f'Found {len(synced_dataset_nc_uuids)} uuids whose {advert_contact_field_name} synced in previous '
                  f'pipeline run...')
 
     # If cache is available, check for uuids to sync in the current pipeline run.
@@ -246,12 +246,12 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
 
     log.info(f'Syncing consent_withdrawn contact_fields in rapidpro... ')
     # Update consent_withdrawn contact field for opt_out contacts
-    consent_withdrawn_contact_field = pipeline_config.rapid_pro_target.sync_config.consent_withdrawn_dataset.rapid_pro_contact_field
+    consent_withdrawn_contact_field = pipeline_config.rapid_pro_target.sync_config.consent_withdrawn_dataset.rapid_pro_contact_field.key
     _sync_advert_contacts_fields_to_rapidpro(cache, opt_out_uuids, consent_withdrawn_contact_field, uuid_table, rapid_pro)
 
     log.info(f'Syncing weekly advert contacts to rapid pro...')
-    advert_contact_field_name = pipeline_config.rapid_pro_target.sync_config.weekly_advert_contact_field.key
-    _sync_advert_contacts_fields_to_rapidpro(cache, weekly_advert_uuids, advert_contact_field_name, uuid_table, rapid_pro)
+    weekly_advert_contact_field = pipeline_config.rapid_pro_target.sync_config.weekly_advert_contact_field.key
+    _sync_advert_contacts_fields_to_rapidpro(cache, weekly_advert_uuids, weekly_advert_contact_field, uuid_table, rapid_pro)
 
     #Update  dataset non relevant groups to rapid_pro
     log.info(f'Syncing contacts who sent non relevant messages for each episode...')
@@ -259,5 +259,5 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
                                                                 pipeline_config.analysis.dataset_configurations)
 
     for dataset, dataset_nc_uuids in non_relevant_uuids.items():
-        advert_contact_field_name = f"{pipeline_config.pipeline_name}_{dataset}_nc_advert_contacts"
-        _sync_advert_contacts_fields_to_rapidpro(cache, dataset_nc_uuids, advert_contact_field_name, uuid_table, rapid_pro)
+        dataset_nc_contact_field_name = f"{pipeline_config.pipeline_name}_{dataset}_nc_advert_contacts"
+        _sync_advert_contacts_fields_to_rapidpro(cache, dataset_nc_uuids, dataset_nc_contact_field_name, uuid_table, rapid_pro)

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -11,6 +11,8 @@ log = Logger(__name__)
 
 CONSENT_WITHDRAWN_KEY = "consent_withdrawn"
 
+#TODO move this to engagement db to rapid_pro sync once we support syncing imputed labels to db
+
 import time #Todo remove before merging
 def time_it(func):
     def wrapper(*args, **kwargs):

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -209,8 +209,8 @@ def _sync_advert_contacts_fields_to_rapidpro(cache, target_uuids, advert_contact
             rapid_pro.update_contact(urn, contact_fields={advert_contact_field_name: "yes"})
             synced_uuids.append(uuid_table.data_to_uuid(urn))
 
-        if cache is not None:
-            cache.set_synced_uuids(advert_contact_field_name, synced_uuids)
+            if cache is not None:
+                cache.set_synced_uuids(advert_contact_field_name, synced_uuids)
 
     else:
         log.info(f'Found {len(uuids_to_sync)} uuids to sync in this run skipping...')

--- a/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
+++ b/src/engagement_db_to_analysis/rapid_pro_advert_functions.py
@@ -95,7 +95,7 @@ def _generate_non_relevant_advert_uuids_by_dataset(participants_by_column, datas
 
     non_relevant_uuids = dict()
     for analysis_dataset_config in dataset_configurations:
-        if analysis_dataset_config.rapid_pro_non_relevant_label is None:
+        if analysis_dataset_config.rapid_pro_non_relevant_field is None:
             continue
 
         assert analysis_dataset_config.dataset_type == DatasetTypes.RESEARCH_QUESTION_ANSWER
@@ -121,7 +121,7 @@ def _generate_non_relevant_advert_uuids_by_dataset(participants_by_column, datas
                     for code in codes:
                         if code.string_value in ["showtime_question", "greeting", "opt_in",
                                                  "about_conversation", "gratitude", "question", "NC"]:
-                            non_relevant_uuids[analysis_dataset_config.rapid_pro_non_relevant_label].add(participant_td["participant_uuid"])
+                            non_relevant_uuids[analysis_dataset_config.rapid_pro_non_relevant_field.label].add(participant_td["participant_uuid"])
 
     return non_relevant_uuids
 
@@ -268,6 +268,7 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
         pipeline_config.rapid_pro_target.sync_config.consent_withdrawn_dataset.rapid_pro_contact_field.label
     consent_withdrawn_contact_field_key = _ensure_contact_field_exists(workspace_contact_fields,
                                                                        consent_withdrawn_contact_field_label, rapid_pro)
+
     _sync_advert_contacts_fields_to_rapid_pro(cache, opt_out_uuids, consent_withdrawn_contact_field_key, uuid_table,
                                              rapid_pro)
 
@@ -275,6 +276,7 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
     weekly_advert_contact_field_label = pipeline_config.rapid_pro_target.sync_config.weekly_advert_contact_field.label
     weekly_advert_contact_field_key = _ensure_contact_field_exists(workspace_contact_fields,
                                                                    weekly_advert_contact_field_label, rapid_pro)
+
     _sync_advert_contacts_fields_to_rapid_pro(cache, weekly_advert_uuids, weekly_advert_contact_field_key, uuid_table,
                                              rapid_pro)
 
@@ -286,5 +288,6 @@ def sync_advert_contacts_to_rapidpro(participants_by_column, uuid_table, pipelin
     for dataset_rapid_pro_non_relevant_label, non_relevant_uuids in non_relevant_uuids.items():
         dataset_rapid_pro_non_relevant_key = _ensure_contact_field_exists(workspace_contact_fields,
                                                                           dataset_rapid_pro_non_relevant_label, rapid_pro)
+
         _sync_advert_contacts_fields_to_rapid_pro(cache, non_relevant_uuids, dataset_rapid_pro_non_relevant_key,
                                                  uuid_table, rapid_pro)

--- a/src/engagement_db_to_rapid_pro/configuration.py
+++ b/src/engagement_db_to_rapid_pro/configuration.py
@@ -11,7 +11,7 @@ class WriteModes:
 
 @dataclass
 class ContactField:
-    key: str
+    key: str = None
     label: str = None
 
 

--- a/src/engagement_db_to_rapid_pro/configuration.py
+++ b/src/engagement_db_to_rapid_pro/configuration.py
@@ -23,6 +23,7 @@ class DatasetConfiguration:
 
 @dataclass
 class EngagementDBToRapidProConfiguration:
+    weekly_advert_contact_field: ContactField
     normal_datasets: Optional[List[DatasetConfiguration]] = None
     consent_withdrawn_dataset: Optional[DatasetConfiguration] = None
     write_mode: str = WriteModes.SHOW_PRESENCE

--- a/src/engagement_db_to_rapid_pro/configuration.py
+++ b/src/engagement_db_to_rapid_pro/configuration.py
@@ -11,8 +11,8 @@ class WriteModes:
 
 @dataclass
 class ContactField:
-    key: str = None
-    label: str = None
+    key: str
+    label: str
 
 
 @dataclass


### PR DESCRIPTION
A major refactor that favors the use of contact fields in place of contact groups. The flows will be configured to split on these contact fields when triggering the SMS ad. 
Please note this treats advert contacts as a product of engagement DB -> analysis because we find ourselves needing to generate contacts based on their labels some of which are imputed in this stage but not necessarily written back to the database. 

Sorry for the major diff. 
